### PR TITLE
Add user init hook

### DIFF
--- a/charts/fdp/README.md
+++ b/charts/fdp/README.md
@@ -101,6 +101,9 @@ The following table lists the configurable parameters of the FDP chart and their
 | `client.service.port` | Service port | `80` |
 | `client.service.targetPort` | Target port | `80` |
 | `client.resources` | Resource requests/limits | See values.yaml |
+| `client.healthCheck.enabled` | Enable readiness/liveness probes | `true` |
+| `client.healthCheck.readiness.*` | Readiness probe configuration | See values.yaml |
+| `client.healthCheck.liveness.*` | Liveness probe configuration | See values.yaml |
 | `client.fdpHost` | FDP Server host | `"fdp-server:80"` |
 
 ### MongoDB Parameters
@@ -153,6 +156,46 @@ The following table lists the configurable parameters of the FDP chart and their
 | `gateway.enabled` | Enable gateway | `false` |
 | `gateway.traefik.enabled` | Enable Traefik routes | `false` |
 | `gateway.traefik.routes` | Traefik route configurations | See values-dev.yaml |
+
+
+### FDP Client Health Checks
+
+The FDP Client includes liveness and readiness probes to ensure Kubernetes properly manages the pod lifecycle. The probes are enabled by default.
+
+**Readiness Probe:**
+- Checks if the FDP Client HTTP endpoint is responding
+- Initial delay: 20 seconds (allows startup time)
+- Period: Every 10 seconds
+- Timeout: 5 seconds
+- Failures before marking unready: 10 attempts
+
+**Liveness Probe (ensures pod recovery):**
+- Checks if the FDP Client is still responsive
+- Initial delay: 30 seconds
+- Period: Every 10 seconds
+- Timeout: 5 seconds
+- Failures before restarting pod: 3 attempts
+
+**Important Note on MongoDB Initialization:**
+The MongoDB post-install Job has a hook-weight of 100, ensuring it only runs **after** the FDP Client deployment is complete and all health checks pass. This guarantees database initialization happens once the system is ready.
+
+To customize health check behavior:
+
+```yaml
+client:
+  healthCheck:
+    enabled: true          # Set to false to disable all health checks
+    readiness:
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 10
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+```
 
 ## Upgrading
 

--- a/charts/fdp/README.md
+++ b/charts/fdp/README.md
@@ -121,6 +121,10 @@ The following table lists the configurable parameters of the FDP chart and their
 | `mongodb.persistence.storageClass` | Storage class | `"harvester-longhorn"` |
 | `mongodb.persistence.size` | Storage size | `"10Gi"` |
 | `mongodb.resources` | Resource requests/limits | See values.yaml |
+| `mongodb.init.enabled` | Initialize with default users | `false` |
+| `mongodb.init.users` | List of users to create | See values.yaml |
+| `mongodb.cleanup.enabled` | Enable user cleanup hook | `false` |
+| `mongodb.cleanup.usersToDelete` | List of user emails to delete | `[]` |
 
 ### GraphDB Parameters
 
@@ -290,6 +294,140 @@ To add new components to the chart:
 2. Add configuration options to `values.yaml`
 3. Update the documentation
 4. Test the new component thoroughly
+
+### MongoDB User Initialization and Cleanup
+
+The chart supports initializing MongoDB with default users and/or cleaning up specific users after FDP deployment completes. Both operations are handled by a single post-install/post-upgrade hook Job that runs **after FDP is fully deployed**.
+
+#### How It Works
+
+- **Post-Install Hook**: The job runs after successful FDP Client deployment
+- **Consolidated Operation**: All user management (deletion and creation) happens in a single MongoDB session
+- **No External Scripts**: All operations are defined inline within the Helm values
+
+#### Enabling User Initialization
+
+To create default users when MongoDB is initialized, set:
+
+```yaml
+mongodb:
+  init:
+    enabled: true
+    users:
+      - uuid: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        firstName: "Admin"
+        lastName: "User"
+        email: "admin@example.com"
+        passwordHash: "$2b$10$M1tsK2jrPBSfmUEYF63l4.mZM4R0u3SKgsiTldp.xjF2LxoLki.R2"
+        role: "ADMIN"
+      - uuid: "131b32be-37d2-49df-b67c-be59aefafde7"
+        firstName: "Test"
+        lastName: "User"
+        email: "test@example.com"
+        passwordHash: "$2b$10$u0cuYZwkBaQEqZ.ooHflTeaJZi73bCkNPmpuMo7rFaAnGjAoi2Lpu"
+        role: "USER"
+```
+
+#### Enabling User Cleanup
+
+To delete specific users after FDP Client deployment (useful for removing default test users or users from previous deployments), set:
+
+```yaml
+mongodb:
+  cleanup:
+    enabled: true
+    usersToDelete:
+      - "albert.einstein@example.com"
+      - "nikola.tesla@example.com"
+```
+
+#### Using Both Features Together
+
+Both can be enabled simultaneously. The job will:
+1. Delete the specified cleanup users
+2. Delete all existing users
+3. Insert the new users from the init configuration
+
+```yaml
+mongodb:
+  init:
+    enabled: true
+    users: [...]
+  cleanup:
+    enabled: true
+    usersToDelete: [...]
+```
+
+#### Important Notes
+
+- **Execution Order**: When both are enabled, cleanup happens first, then initialization
+- **No Plaintext Passwords Stored**: Only password hashes are used; the `password` field in values.yaml is optional and for reference only
+- **Idempotent**: The job can be safely re-run (it automatically cleans up previous Job runs)
+- **Waits for FDP**: The job only runs after all FDP components are deployed and ready
+
+#### Generating Bcrypt Password Hashes
+
+The FDP system uses bcrypt for password hashing. You need to generate bcrypt hashes for each user's password and populate the `passwordHash` field.
+
+**Important:** The `password` field is optional and only for documentation/reference. The system only uses the `passwordHash` field for authentication.
+
+**Quick Docker Command (Recommended):**
+
+```bash
+docker run --rm python:3.11-slim bash -c "pip install -q bcrypt && python3 -c \"import bcrypt; print(bcrypt.hashpw(b'your-password-here', bcrypt.gensalt(10)).decode())\""
+```
+
+**Example:**
+```bash
+$ docker run --rm python:3.11-slim bash -c "pip install -q bcrypt && python3 -c \"import bcrypt; print(bcrypt.hashpw(b'AdminPassword123!', bcrypt.gensalt(10)).decode())\""
+$2b$10$M1tsK2jrPBSfmUEYF63l4.mZM4R0u3SKgsiTldp.xjF2LxoLki.R2
+```
+
+**If Python is installed locally:**
+
+```bash
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password-here', bcrypt.gensalt(10)).decode())"
+```
+
+**Important Security Notes:**
+- Always generate bcrypt hashes with a cost factor of at least 10
+- In production, use secure methods (not online generators)
+- Never commit cleartext passwords to version control
+- Each run produces a different hash (due to random salt) - this is normal and secure!
+- Always change the default passwords in production
+
+#### Generating UUIDs
+
+Each user needs a unique UUID (version 4). You can generate these using minimal standard tools:
+
+**Example: Using Python (no external dependencies):**
+
+```bash
+$ python3 -c "import uuid; print(uuid.uuid4())"
+f47ac10b-58cc-4372-a567-0e02b2c3d479
+```
+
+**Using Linux kernel:**
+
+```bash
+cat /proc/sys/kernel/random/uuid
+```
+
+
+#### User Cleanup
+
+After deployment, you can optionally delete specific users using the cleanup hook:
+
+```yaml
+mongodb:
+  cleanup:
+    enabled: true
+    usersToDelete:
+      - "albert.einstein@example.com"
+      - "nikola.tesla@example.com"
+```
+
+This is useful if you want to remove default users while keeping custom users created during initialization.
 
 ### Password Security Guidelines
 

--- a/charts/fdp/templates/fdp-client/deployment.yaml
+++ b/charts/fdp/templates/fdp-client/deployment.yaml
@@ -28,5 +28,23 @@ spec:
          env:
          - name: FDP_HOST
            value: {{ include "fdp.fullname" . }}-server:{{ .Values.server.service.port }}
+         {{- if .Values.client.healthCheck.enabled }}
+         readinessProbe:
+           httpGet:
+             path: /
+             port: http
+           initialDelaySeconds: {{ .Values.client.healthCheck.readiness.initialDelaySeconds }}
+           periodSeconds: {{ .Values.client.healthCheck.readiness.periodSeconds }}
+           timeoutSeconds: {{ .Values.client.healthCheck.readiness.timeoutSeconds }}
+           failureThreshold: {{ .Values.client.healthCheck.readiness.failureThreshold }}
+         livenessProbe:
+           httpGet:
+             path: /
+             port: http
+           initialDelaySeconds: {{ .Values.client.healthCheck.liveness.initialDelaySeconds }}
+           periodSeconds: {{ .Values.client.healthCheck.liveness.periodSeconds }}
+           timeoutSeconds: {{ .Values.client.healthCheck.liveness.timeoutSeconds }}
+           failureThreshold: {{ .Values.client.healthCheck.liveness.failureThreshold }}
+         {{- end }}
          resources:
           {{- toYaml .Values.client.resources | nindent 10 }}

--- a/charts/fdp/templates/mongodb/job-cleanup.yaml
+++ b/charts/fdp/templates/mongodb/job-cleanup.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "fdp.fullname" . }}-mongodb-init
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-weight": "100"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     {{- include "fdp.labels" . | nindent 4 }}

--- a/charts/fdp/templates/mongodb/job-cleanup.yaml
+++ b/charts/fdp/templates/mongodb/job-cleanup.yaml
@@ -1,0 +1,89 @@
+{{- if and .Values.mongodb.enabled (not .Values.mongodb.useExternal) (or .Values.mongodb.init.enabled .Values.mongodb.cleanup.enabled) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "fdp.fullname" . }}-mongodb-init
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "fdp.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  backoffLimit: 3
+  completionMode: NonIndexed
+  template:
+    metadata:
+      labels:
+        {{- include "fdp.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: database
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: mongodb-init
+        image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+        imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Waiting for MongoDB to be ready..."
+          until mongosh --host {{ include "fdp.fullname" . }}-mongodb:27017 -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval "db.adminCommand('ping')" > /dev/null 2>&1; do
+            echo "Waiting for MongoDB..."
+            sleep 2
+          done
+          echo "MongoDB is ready. Running initialization..."
+          
+          mongosh --host {{ include "fdp.fullname" . }}-mongodb:27017 -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin << 'MONGOEOF'
+          use {{ .Values.mongodb.auth.database }};
+          
+          {{- if .Values.mongodb.cleanup.enabled }}
+          // Delete specified users
+          db.user.deleteMany({
+            email: {
+              $in: [
+                {{- range .Values.mongodb.cleanup.usersToDelete }}
+                "{{ . }}",
+                {{- end }}
+              ]
+            }
+          });
+          console.log("Deleted default users");
+          {{- end }}
+          
+          {{- if .Values.mongodb.init.enabled }}
+          // Delete all existing users first
+          db.user.deleteMany({});
+          
+          // Insert new users
+          {{- range .Values.mongodb.init.users }}
+          db.user.insertOne({
+            "_id": ObjectId(),
+            "uuid": "{{ .uuid }}",
+            "firstName": "{{ .firstName }}",
+            "lastName": "{{ .lastName }}",
+            "email": "{{ .email }}",
+            "passwordHash": "{{ .passwordHash }}",
+            "role": "{{ .role }}",
+            "_class": "nl.dtls.fairdatapoint.entity.user.User"
+          });
+          {{- end }}
+          console.log("Created new users");
+          {{- end }}
+          
+          MONGOEOF
+          echo "Initialization completed successfully"
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fdp.fullname" . }}-secrets
+              key: MONGODB_ROOT_USERNAME
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fdp.fullname" . }}-secrets
+              key: MONGODB_ROOT_PASSWORD
+{{- end }}

--- a/charts/fdp/values.yaml
+++ b/charts/fdp/values.yaml
@@ -34,14 +34,14 @@ server:
       memory: "1Gi"
       cpu: "500m"
   
-   # Environment variables
-    env:
-     clientUrl: "https://gdi-fdp.example.com"
-     persistentUrl: ""  # Defaults to clientUrl if empty
-     title: "BG GDI DEV FAIR Data Point"
-     description: "A FAIR Data Point instance for development and testing purposes."
-     healthSolrEnabled: true
-     infoEnabled: true
+  # Environment variables
+  env:
+    clientUrl: "https://gdi-fdp.example.com"
+    persistentUrl: ""  # Defaults to clientUrl if empty
+    title: "BG GDI DEV FAIR Data Point"
+    description: "A FAIR Data Point instance for development and testing purposes."
+    healthSolrEnabled: true
+    infoEnabled: true
   
   # MongoDB connection
   mongo:
@@ -85,8 +85,8 @@ client:
       memory: "512Mi"
       cpu: "250m"
   
-   # FDP Server connection
-   # fdpHost is now dynamically set to the fdp-server service URL and should not be overridden
+  # FDP Server connection
+  # fdpHost is now dynamically set to the fdp-server service URL and should not be overridden
 
 # MongoDB configuration
 mongodb:
@@ -145,6 +145,44 @@ mongodb:
     limits:
       memory: "1Gi"
       cpu: "500m"
+  
+  # Initialize MongoDB with default users
+  # Set enabled: false to skip user initialization
+  init:
+    enabled: false
+    # List of users to create on first deployment
+    # Passwords are hashed using bcrypt (cost factor 10)
+    # The 'password' field below is optional and only for reference - the system uses 'passwordHash'
+    users:
+      - uuid: "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        firstName: "Admin"
+        lastName: "User"
+        email: "admin@example.com"
+        # Optional: plaintext password for reference only (not used by the system)
+        password: "AdminPassword123!"
+        # Use generated bcrypt hash (cost factor 10)
+        # Example to generate: docker run --rm python:3.11-slim bash -c "pip install -q bcrypt && python3 -c \"import bcrypt; print(bcrypt.hashpw(b'AdminPassword123!', bcrypt.gensalt(10)).decode())\""
+        passwordHash: "$2b$10$M1tsK2jrPBSfmUEYF63l4.mZM4R0u3SKgsiTldp.xjF2LxoLki.R2"
+        role: "ADMIN"
+      - uuid: "131b32be-37d2-49df-b67c-be59aefafde7"
+        firstName: "Test"
+        lastName: "User"
+        email: "test@example.com"
+        # Optional: plaintext password for reference only (not used by the system)
+        password: "TestPassword123!"
+        # Use generated bcrypt hash (cost factor 10)
+        # Example to generate: docker run --rm python:3.11-slim bash -c "pip install -q bcrypt && python3 -c \"import bcrypt; print(bcrypt.hashpw(b'TestPassword123!', bcrypt.gensalt(10)).decode())\""
+        passwordHash: "$2b$10$u0cuYZwkBaQEqZ.ooHflTeaJZi73bCkNPmpuMo7rFaAnGjAoi2Lpu"
+        role: "USER"
+  
+  # Cleanup configuration - removes specified users after deployment
+  cleanup:
+    enabled: false
+    # List of email addresses to delete after deployment
+    # This is useful for removing default users if you want to start with a clean slate
+    usersToDelete:
+      - "albert.einstein@example.com"
+      - "nikola.tesla@example.com"
 
 # GraphDB configuration
 graphdb:

--- a/charts/fdp/values.yaml
+++ b/charts/fdp/values.yaml
@@ -85,6 +85,22 @@ client:
       memory: "512Mi"
       cpu: "250m"
   
+  # Health checks for the FDP Client container
+  healthCheck:
+    enabled: true
+    # Readiness probe - checks if container is ready to serve traffic
+    readiness:
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 10
+    # Liveness probe - checks if container needs to be restarted
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+  
   # FDP Server connection
   # fdpHost is now dynamically set to the fdp-server service URL and should not be overridden
 


### PR DESCRIPTION
Adds mongo script I use for cleaning up default users and adding new admin/test user (xref https://github.com/GenomicDataInfrastructure/GDI-K8s-Resources/issues/1), and explains how to generate UUID and password hash with examples for the new users. This is based on my working docker-compose script, but I am still struggling to test in a proper kubernetes environment, so still WIP, but thought I'd stop postponing until fully tested and make the PR.

PS: I also changed some indentation in the values file so that helm lint passes.

Also, I added a healthcheck to the FDP client. I needed to add this to my docker compose setup to ensure that the mongo init doesn't run until after FDP is done initializing, since the mongo initialization is done by the FDP, so removing the users before it initializes is not useful as they will be recreated by FDP